### PR TITLE
test_realsense_streams: Fix linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(Boost REQUIRED COMPONENTS thread)
 find_package(gazebo REQUIRED)
+find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
@@ -43,6 +44,7 @@ target_link_libraries(
     test_realsense_streams
     ${catkin_LIBRARIES}
     ${GTEST_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 add_dependencies(test_realsense_streams ${catkin_EXPORTED_TARGETS})
 


### PR DESCRIPTION
While attempting to build the project, I am getting this error while building test_realsense_streams:

```
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/5/../../../../lib/libgtest.a(gtest-all.cc.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Ubuntu 16.04, GCC 5.4.0, ROS kinetic, gtest 1.7.0

This PR attempts to fix the error by linking against threading library explicitly.