### PR TITLE
Add prefix to URDF to allow multiple cameras in the same scene

### DIFF
--- a/urdf/realsense-RS200.macro.xacro
+++ b/urdf/realsense-RS200.macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--Develped by Daniel Ordonez 22.05.2018 - daniels.ordonez@gmail.com
-    INFORMATIONd:
+    INFORMATION:
         This xacro file a URDF representation of the intel real sense RS200 with the
         virtual links representing the position of:
             * The RGB color camera
@@ -10,10 +10,10 @@
         Configured to work with Gazebo if desired.
 -->
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-<xacro:macro name="realsense-rs200">
+<xacro:macro name="realsense-rs200" params="prefix parent *origin">
 
     <!-- Camera link -->
-    <link name="rs200_camera">
+    <link name="${prefix}rs200_camera">
         <visual>
             <origin rpy="0 0 0" xyz="0 0 0"/>
             <geometry>
@@ -38,36 +38,43 @@
         </inertial>
     </link>
 
+    <!-- Connect camera to parent frame-->
+    <joint name="${prefix}realsense_joint" type="fixed">
+        <parent link="${parent}"/>
+        <child link="${prefix}rs200_camera"/>
+        <xacro:insert_block name="origin"/>
+    </joint>
+
     <!-- Virtual links representing the cameras positons and orientations-->
-    <link name="color" />
-    <link name="depth" />
-    <link name="ired1" />
-    <link name="ired2" />
+    <link name="${prefix}color" />
+    <link name="${prefix}depth" />
+    <link name="${prefix}ired1" />
+    <link name="${prefix}ired2" />
 
     <!-- Joints positioning the virtual links with respect to the camera main link-->
-    <joint name="color_joint" type="fixed">
-        <parent link="rs200_camera" />
-        <child link="color" />
+    <joint name="${prefix}color_joint" type="fixed">
+        <parent link="${prefix}rs200_camera" />
+        <child link="${prefix}color" />
         <!-- <origin xyz="0 -0.046 0.004" rpy="0 0 0"/> -->
         <!-- The default position is change since in Rviz the cloud depth axis is Z not X-->
         <origin xyz="0 -0.046 0.004" rpy="${pi/2} ${pi} ${pi/2}"/>
     </joint>
 
-    <joint name="depth_joint" type="fixed">
-        <parent link="rs200_camera" />
-        <child link="depth" />
+    <joint name="${prefix}depth_joint" type="fixed">
+        <parent link="${prefix}rs200_camera" />
+        <child link="${prefix}depth" />
         <origin xyz="0 -0.03 0.004" rpy="0 0 0"/>
     </joint>
 
-    <joint name="ired1_joint" type="fixed">
-        <parent link="rs200_camera" />
-        <child link="ired1" />
+    <joint name="${prefix}ired1_joint" type="fixed">
+        <parent link="${prefix}rs200_camera" />
+        <child link="${prefix}ired1" />
         <origin xyz="0 -0.06 0.004" rpy="0 0 0"/>
     </joint>
 
-    <joint name="ired2_joint" type="fixed">
-        <parent link="rs200_camera" />
-        <child link="ired2" />
+    <joint name="${prefix}ired2_joint" type="fixed">
+        <parent link="${prefix}rs200_camera" />
+        <child link="${prefix}ired2" />
         <origin xyz="0 0.01 0.004" rpy="0 0 0"/>
     </joint>
 
@@ -81,7 +88,7 @@
     </gazebo>
 
     <!-- Load parameters to model's main link-->
-    <gazebo reference="rs200_camera">
+    <gazebo reference="${prefix}rs200_camera">
         <self_collide>0</self_collide>
         <enable_wind>0</enable_wind>
         <kinematic>0</kinematic>
@@ -98,7 +105,7 @@
 
         <sensor name="color" type="camera">
             <pose frame="">0 -0.046 0.004 0 0 0</pose>
-            <camera name="__default__">
+            <camera name="${prefix}rs200_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
                 <width>640</width>
@@ -121,7 +128,7 @@
         </sensor>
         <sensor name="ired1" type="camera">
             <pose frame="">0 -0.06 0.004 0 0 0</pose>
-            <camera name="__default__">
+            <camera name="${prefix}rs200_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
                 <width>640</width>
@@ -144,7 +151,7 @@
         </sensor>
         <sensor name="ired2" type="camera">
             <pose frame="">0 0.01 0.004 0 0 0</pose>
-            <camera name="__default__">
+            <camera name="${prefix}rs200_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
                 <width>640</width>
@@ -167,7 +174,7 @@
         </sensor>
         <sensor name="depth" type="depth">
             <pose frame="">0 -0.03 0.004 0 0 0</pose>
-            <camera name="__default__">
+            <camera name="${prefix}rs200_camera">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
                     <width>640</width>

--- a/urdf/rs200_simulation.xacro
+++ b/urdf/rs200_simulation.xacro
@@ -4,16 +4,12 @@
     This is an example of how to use the realsense-rs200 macro function.
 -->
 <robot name="robot_with_rs200" xmlns:xacro="http://ros.org/wiki/xacro">
+    <link name="world"/>
+
     <!-- Import macro for realsense-RS200 camera-->
     <xacro:include filename="$(find realsense_gazebo_plugin)/urdf/realsense-RS200.macro.xacro"/>
     <!-- Create camera instance -->
-    <xacro:realsense-rs200/>
-    <!-- Gazebo world link required to position the robot with respect to origin-->
-    <link name="world"/>
-    <!-- Place camera referenced to world frame-->
-    <joint name="realsense_joint" type="fixed">
-        <parent link="world"/>
-        <child link="rs200_camera"/>
-        <origin rpy="0 0 0" xyz="0 0 1.0"/>
-    </joint>
+    <xacro:realsense-rs200 prefix="" parent="world">
+        <origin xyz="0 0 1.0" rpy="0 0 0" />   
+    </xacro:realsense-rs200>
 </robot>


### PR DESCRIPTION
This adds a prefix, parent and origin parameter to the URDF macro.

The prefix is necessary for multiple cameras to exist in gazebo. Otherwise their names would collide.

The parent and origin parameters are a standard way to define these kinds of macros, and result in a much easier to read robot definition file.