### PR TITLE
URDFs edited to handle multi-links. Example added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@ Then open Rviz, and display the `/realsense/camera/depth_registered/points` topi
 roslaunch realsense_gazebo_plugin realsense_urdf.launch
 ```
 
-This will behave the same as `realsense.launch` mentioned above, with the difference that it spawns the model from a URDF (see `urdf` folder).
+This will behave the same as `realsense.launch` mentioned above, with the difference that it spawns the model from a URDF (`urdf/rs200_simulation.xacro`).
 You can reuse this to plug the sensor in the robot of your choice.
+
+### Multi-link URDF
+
+```bash
+roslaunch realsense_gazebo_plugin realsense_urdf_multilink.launch
+```
+
+Here is an example of how to attach the Realsense to other links; the URDF used here is (`urdf/rs200_simulation_multilink.xacro`).
 
 ## Dependencies
 

--- a/launch/realsense_urdf_multilink.launch
+++ b/launch/realsense_urdf_multilink.launch
@@ -1,0 +1,15 @@
+<launch>
+    <param
+        name="robot_description"
+        command="$(find xacro)/xacro --inorder '$(find realsense_gazebo_plugin)/urdf/rs200_simulation_multilink.xacro'"
+    />
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    </include>
+    <node
+        name="spawn_model"
+        pkg="gazebo_ros"
+        type="spawn_model"
+        args="-urdf -param robot_description -model rs200"
+    />
+    <node name="state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+</launch>

--- a/urdf/realsense-RS200.macro.xacro
+++ b/urdf/realsense-RS200.macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--Develped by Daniel Ordonez 22.05.2018 - daniels.ordonez@gmail.com
-    INFORMATIONd:
+    INFORMATION:
         This xacro file a URDF representation of the intel real sense RS200 with the
         virtual links representing the position of:
             * The RGB color camera
@@ -8,9 +8,13 @@
             * Infrared 2 camera
             * Virtual depth coordinate frame
         Configured to work with Gazebo if desired.
+
+    Update of Maik93: in order to handle camera positions while attaching the Realsense to other links,
+    optional parameters "parent_link, origin_x, origin_y, origin_z" are implemented.
+    See urdf/rs200_simulation_multilink.xacro for details.
 -->
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-<xacro:macro name="realsense-rs200">
+<xacro:macro name="realsense-rs200" params="parent_link:='rs200_camera' origin_x:=0 origin_y:=0 origin_z:=0">
 
     <!-- Camera link -->
     <link name="rs200_camera">
@@ -49,7 +53,7 @@
         <parent link="rs200_camera" />
         <child link="color" />
         <!-- <origin xyz="0 -0.046 0.004" rpy="0 0 0"/> -->
-        <!-- The default position is change since in Rviz the cloud depth axis is Z not X-->
+        <!-- The default position is changed since in Rviz the cloud depth axis is Z not X-->
         <origin xyz="0 -0.046 0.004" rpy="${pi/2} ${pi} ${pi/2}"/>
     </joint>
 
@@ -81,7 +85,7 @@
     </gazebo>
 
     <!-- Load parameters to model's main link-->
-    <gazebo reference="rs200_camera">
+    <gazebo reference="${parent_link}">
         <self_collide>0</self_collide>
         <enable_wind>0</enable_wind>
         <kinematic>0</kinematic>
@@ -97,7 +101,7 @@
         <min_depth>0</min_depth>-->
 
         <sensor name="color" type="camera">
-            <pose frame="">0 -0.046 0.004 0 0 0</pose>
+            <pose frame="">${origin_x + 0} ${origin_y - 0.046} ${origin_z + 0.004} 0 0 0</pose>
             <camera name="__default__">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
@@ -120,7 +124,7 @@
             <visualize>1</visualize>
         </sensor>
         <sensor name="ired1" type="camera">
-            <pose frame="">0 -0.06 0.004 0 0 0</pose>
+            <pose frame="">${origin_x + 0} ${origin_y - 0.06} ${origin_z + 0.004} 0 0 0</pose>
             <camera name="__default__">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
@@ -143,7 +147,7 @@
             <visualize>0</visualize>
         </sensor>
         <sensor name="ired2" type="camera">
-            <pose frame="">0 0.01 0.004 0 0 0</pose>
+            <pose frame="">${origin_x + 0} ${origin_y + 0.01} ${origin_z + 0.004} 0 0 0</pose>
             <camera name="__default__">
             <horizontal_fov>1.047</horizontal_fov>
             <image>
@@ -166,7 +170,7 @@
             <visualize>0</visualize>
         </sensor>
         <sensor name="depth" type="depth">
-            <pose frame="">0 -0.03 0.004 0 0 0</pose>
+            <pose frame="">${origin_x + 0} ${origin_y - 0.03} ${origin_z + 0.004} 0 0 0</pose>
             <camera name="__default__">
             <horizontal_fov>1.047</horizontal_fov>
             <image>

--- a/urdf/rs200_simulation.xacro
+++ b/urdf/rs200_simulation.xacro
@@ -6,11 +6,15 @@
 <robot name="robot_with_rs200" xmlns:xacro="http://ros.org/wiki/xacro">
     <!-- Import macro for realsense-RS200 camera-->
     <xacro:include filename="$(find realsense_gazebo_plugin)/urdf/realsense-RS200.macro.xacro"/>
+
     <!-- Create camera instance -->
     <xacro:realsense-rs200/>
-    <!-- Gazebo world link required to position the robot with respect to origin-->
+
+    <!-- Gazebo world link required to position the robot with respect to origin -->
+    <!-- the name "world" is mandatory for Gazebo! -->
     <link name="world"/>
-    <!-- Place camera referenced to world frame-->
+
+    <!-- Place camera referenced to world frame -->
     <joint name="realsense_joint" type="fixed">
         <parent link="world"/>
         <child link="rs200_camera"/>

--- a/urdf/rs200_simulation_multilink.xacro
+++ b/urdf/rs200_simulation_multilink.xacro
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--Develped by Maik93 on 29.10.2018
+  INFORMATION:
+    This is an example of how to use the realsense-rs200 macro function attached to other links.
+-->
+<robot name="robot_with_rs200" xmlns:xacro="http://ros.org/wiki/xacro">
+    <!-- Import macro for realsense-RS200 camera-->
+    <xacro:include filename="$(find realsense_gazebo_plugin)/urdf/realsense-RS200.macro.xacro"/>
+    
+    <!-- Gazebo world link required to position the robot with respect to origin -->
+    <link name="world"/>
+
+    <!-- main body of the robot -->
+    <link name="box">
+        <visual>
+            <origin rpy="0 0 0" xyz="0 0 0"/>
+            <geometry>
+                <box size="0.1 0.1 0.1"/>
+            </geometry>
+        </visual>
+        <collision name="box_collision">
+            <origin rpy="0 0 0" xyz="0 0 0"/>
+            <geometry>
+                <box size="0.1 0.1 0.1"/>
+            </geometry>
+        </collision>
+    </link>
+
+    <!-- Create camera instance. To define correctly camera positions for Gazebo plugin:
+            - give the parent link name
+            - add origin_x, origin_y and origin_z according to joint's origin "realsense_joint" -->
+    <xacro:realsense-rs200 parent_link="box" origin_z="0.2"/>
+
+    <!-- world link is only a reference for your odometry -->
+    <joint name="world_joint" type="floating">
+        <parent link="world"/>
+        <child link="box"/>
+    </joint>
+
+    <!-- Place camera rigidly connected to box frame -->
+    <joint name="realsense_joint" type="fixed">
+        <parent link="box"/>
+        <child link="rs200_camera"/>
+        <origin rpy="0 0 0" xyz="0 0 0.2"/>
+    </joint>
+</robot>


### PR DESCRIPTION
As exposed in issue #26, there was a problem with Gazebo and its sensor plugin when the camera was attached to not-fixed joints.

Indeed in Gazebo, when a link is rigidly attached to an other, its name is lost and only that one of the parent link remains:
![screenshot from 2018-10-29 12-00-27](https://user-images.githubusercontent.com/7384336/47645777-44185480-db72-11e8-8ca5-0acf889330ba.png)
This will break Gazebo Plugin reference ([`realsense-RS200.macro.xacro:84`](https://github.com/SyrianSpock/realsense_gazebo_plugin/blob/kinetic-devel/urdf/realsense-RS200.macro.xacro#L84) should need `box` as reference for the above picture) causing all cameras in Gazebo to overlap.
I've expanded `realsense-RS200.macro.xacro` in order to handle this problem.

Notice that while it already worked in rviz (all TF was displayed correctly), enabling `<visualize>1</visualize>` in `realsense-RS200.macro.xacro:147,170,192` will show in Gazebo the overlapping cameras.

PS: I'm running Ubuntu 16.04 and ROS Kinetic, I've noticed only now that all this files are different in the `master` branch. I can't say if the problem is still present here because I can't run it.