### PR TITLE
Overridable camera_name arg of depth_proc.launch

### DIFF
--- a/launch/depth_proc.launch
+++ b/launch/depth_proc.launch
@@ -2,7 +2,7 @@
   <param name="use_sim_time" value="true" />
 
   <!-- See name assigned in realsense-RS200.macro.xacro -->
-  <arg name="camera_name" value="r200" />
+  <arg name="camera_name" default="r200" />
 
   <arg name="rgb_camera_info" value="/$(arg camera_name)/camera/color/camera_info"/>
   <arg name="rgb_img_rect" value="/$(arg camera_name)/camera/color/image_raw"/>  <!--Rectified color image-->


### PR DESCRIPTION
Thanks for the very useful plugin! I have a further suggestion to make it easier to integrate :)

Doing so allows inclusion in external launch files using other cameras